### PR TITLE
Add support for tags on the cloudwatch log group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,19 +9,20 @@ data "template_file" "log_policy" {
 }
 
 resource "aws_iam_role" "iam_log_role" {
-  name = "${var.prefix}-flow-log-role"
+  name               = "${var.prefix}-flow-log-role"
   assume_role_policy = "${data.template_file.assume_role_policy.rendered}"
 }
 
 resource "aws_iam_role_policy" "log_policy" {
-  name = "${var.prefix}-flow-log-policy"
-  role = "${aws_iam_role.iam_log_role.id}"
+  name   = "${var.prefix}-flow-log-policy"
+  role   = "${aws_iam_role.iam_log_role.id}"
   policy = "${data.template_file.log_policy.rendered}"
 }
 
-
 resource "aws_cloudwatch_log_group" "flow_log_group" {
   name = "${var.log_group_name == "" ? local.default_log_group_name : var.log_group_name}"
+
+  tags = "${var.tags}"
 }
 
 resource "aws_flow_log" "vpc_flow_log" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,11 +2,11 @@ variable "vpc_id" {}
 
 variable "prefix" {
   description = "The prefix for the resource names. You will probably want to set this to the name of your VPC, if you have multiple."
-  default = "vpc"
+  default     = "vpc"
 }
 
 variable "traffic_type" {
-  default = "ALL"
+  default     = "ALL"
   description = "https://www.terraform.io/docs/providers/aws/r/flow_log.html#traffic_type"
 }
 
@@ -15,7 +15,13 @@ variable "traffic_type" {
 locals {
   default_log_group_name = "${var.prefix}-flow-log"
 }
+
 variable "log_group_name" {
-  default = ""
+  default     = ""
   description = "Defaults to `$${default_log_group_name}`"
+}
+
+variable "tags" {
+  default     = []
+  description = "A map containing tags to apply to the cloudwatch_log_group"
 }


### PR DESCRIPTION
Add a tags variable that is applied to the `aws_cloudwatch_log_group` resource.