### PR TITLE
Add support for terraform-docs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ module "flow_logs" {
 }
 ```
 
-See the [optional variables](variables.tf).
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
[terraform-docs](https://github.com/segmentio/terraform-docs) is a create tool to keep module parameter documentation up-to-date, especially when combined with [pre-commit](https://pre-commit.com/) hooks that can update documentation on every commit.

This change adds the necessary placeholders to README.md that are used by `terraform-docs` to update parameter documentation.